### PR TITLE
BLD: Set minimum pytorch version to avoid bug in python 3.10+

### DIFF
--- a/requirements-dev
+++ b/requirements-dev
@@ -4,7 +4,7 @@ importlib-metadata
 importlib-resources
 matplotlib
 numpy ~=1.21
-pytorch
+pytorch ~=1.12
 scikit-image
 scipy
 tqdm

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ install_requires =
     importlib-resources; python_version < "3.7"
     matplotlib
     numpy ~=1.21
-    torch
+    torch ~=1.12
     scikit-image
     scipy
     tqdm


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/72239

We need this patch to avoid import errors with ParallelData and python 3.10+.